### PR TITLE
📕 Developer portal spelling fix

### DIFF
--- a/submit/index.html
+++ b/submit/index.html
@@ -8,7 +8,7 @@
 		<script type="text/javascript" src="main.js"></script>
 		<script type="text/javascript" src="res/jszip.min.js"></script>
 		<script type="text/javascript" src="res/filesaver.min.js"></script>
-		<!-- Rebble Dev Portal Version 1.0 -->
+ 		<!-- Rebble Dev Portal Version 1.1 --> 
 	</head>
   <body onload="start()">
 
@@ -63,7 +63,7 @@
       <div class="br-sm"></div>
 
       <div class="container">
-        Have a pebble app you'd like to submit to the <a href="https://apps.rebble.io">app store</a>? This tool can help! Before you start, make sure you have read <a href="https://developer.rebble.io/developer.pebble.com/guides/appstore-publishing/publishing-an-app/index.html"> the app publishing guidelines </a> and have all the listed resourses ready.
+        Have a pebble app you'd like to submit to the <a href="https://apps.rebble.io">app store</a>? This tool can help! Before you start, make sure you have read <a href="https://developer.rebble.io/developer.pebble.com/guides/appstore-publishing/publishing-an-app/index.html"> the app publishing guidelines </a> and have all the listed resources ready.
         When you are finished, this tool will generate a zip file which you will then need to send to @joshua on <a href="http://discord.gg/aRUAYFN"> the rebble discord. </a>
         <br><br> For more information, see the relevant <a href="https://github.com/pebble-dev/wiki/wiki/Preparing-a-new-app-for-the-Rebble-App-Store">rebble wiki page</a>
       </div>

--- a/submit/readme.md
+++ b/submit/readme.md
@@ -4,13 +4,13 @@
 
 ## Intro
 
-This portal is for developers of apps or watchfaces for the pebble smartwatch who want to deploy their application to the [rebble appstore](https://apps.rebble.io). As per [this post](https://github.com/pebble-dev/wiki/wiki/Preparing-a-new-app-for-the-Rebble-App-Store), you can get your app on the appstore by creating a .zip with a yaml file and all the resources. This project provides a form which accepts your project resources and automatically creates the .yaml file, wrapping everything up in a nice .zip.   
+The developer portal is for developers of apps or watchfaces who want to deploy their application to the [rebble appstore](https://apps.rebble.io). As per [this post](https://github.com/pebble-dev/wiki/wiki/Preparing-a-new-app-for-the-Rebble-App-Store), you can get your app on the appstore by creating a .zip with a yaml file and all the resources. This project provides a form which accepts your project resources and automatically creates the .yaml file, wrapping everything up in a nice .zip.   
 
 ## Production
 
-There is an alternate version, with the same functionality at at [willow.systems/pebble/dev-portal/](https://willow.systems/pebble/dev-portal/). See [this repo](https://github.com/Willow-Systems/psuedo-dev-portal) for that source. This repository is designed to be put under the rebble.io domain name
+Production deployment is available at [rebble.io/submit](https://rebble.io/submit)
 
-## Instructions
+## Future Improvements
 
-For full instructions and explanations on the fields, see [the accompanying blog post](https://willow.systems/a-quick-and-dirty-dev-portal-for-the-rebble-app-store/)
+See Issues
 


### PR DESCRIPTION
Pulling in master from dev-portal repo. Minor spelling fix of 'resourses' -> 'resources'. Also pulling across the newest readme