### PR TITLE
Add author support

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 
 <article class="post">
     <div class="text-content">
-        <p class="metadata">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
+	    <p class="metadata">{{ page.date | date: "%b %-d, %Y" }}{% if page.author %} • by <a href="{% if page.alt-bio %}{{ page.alt-bio }}{% else %}/team#person-{{ page.author }}{% endif %}">{{ page.author }}</a>{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
         <h2>{{ page.title }}</h2>
         {{ content }}
     </div>

--- a/_posts/2016-12-09-rebble-pebble-reborn.md
+++ b/_posts/2016-12-09-rebble-pebble-reborn.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Rebble: Pebble Reborn"
 date:   2016-12-09 11:21:42
+author: "Ish Ot Jr."
 # categories: 
 ---
 

--- a/_posts/2016-12-19-rebble-community-update-1.md
+++ b/_posts/2016-12-19-rebble-community-update-1.md
@@ -3,6 +3,7 @@ layout: post
 title: "Rebble Community Update 1"
 date:   2016-12-19 18:49:42
 # categories: community
+author: "Ish Ot Jr."
 ---
 
 A cordial hello, and welcome, to our inaugural *Rebble Community Update*!  Herein lies a casual compendium of recent activity within the community.  If you'd like to add something, [send us a tweet](https://twitter.com/pebble_dev), or better still, [submit a pull request](https://github.com/pebble-dev/pebble-dev.github.io/pulls)! :bowtie:  

--- a/_posts/2017-01-31-rebble-community-update-2.md
+++ b/_posts/2017-01-31-rebble-community-update-2.md
@@ -3,6 +3,7 @@ layout: post
 title: "Rebble Community Update 2"
 date:   2017-01-31 19:49:42
 # categories: community
+author: "Ish Ot Jr."
 ---
 
 Welcome to the first *Rebble Community Update* of 2017!  Please peruse our paraphrased prospectus of progress over the preceding period.  If you'd like to add something, [send us a tweet](https://twitter.com/pebble_dev), or better still, [submit a pull request](https://github.com/pebble-dev/pebble-dev.github.io/pulls)! :bowtie:  

--- a/_posts/2017-04-23-rebble-community-update-3.md
+++ b/_posts/2017-04-23-rebble-community-update-3.md
@@ -3,6 +3,7 @@ layout: post
 title: "Rebble Community Update 3"
 date:   2017-04-23 11:42:42
 # categories: community
+author: "Ish Ot Jr."
 ---
 
 *"Where is my Rebble Community Update?"* [the people cry](https://www.reddit.com/r/pebble/comments/66w4h0/rebble_update/)!  At last, it is here, and this time, rather than the typical broad yet shallow summary, we thought we'd take a closer look at a particular area of import: [firmware](http://rebble.io/projects/#firmware).  Familiarize yourself with our feats in this forward-looking firmware-focused feature.  If you'd like to add something, [send us a tweet](https://twitter.com/pebble_dev), or better still, [submit a pull request](https://github.com/pebble-dev/pebble-dev.github.io/pulls)! :bowtie:  

--- a/_posts/2018-01-22-rebble-community-update-4.md
+++ b/_posts/2018-01-22-rebble-community-update-4.md
@@ -3,6 +3,7 @@ layout: post
 title: "Rebble Community Update 4: Love and Rockets!"
 date:   2018-01-22 11:42:42
 # categories: community
+author: "Ish Ot Jr."
 ---
 
 Welcome to the first *Rebble Community Update* of 2018! :heart: :rocket:  One of [my](https://twitter.com/IShJR) most important roles in the Rebble project is *Lead Emoji Sprinkler*, which requires fastidious monitoring of the [Rebble Discord](http://discord.gg/aRUAYFN) to ensure that all comments indicating progress or good will are met with a swift :rocket: or :heart: respectively - and lately the emoji have been flowing liberally as the firmware team's progress continues to :rocket: thanks to the prodigious output of new and old [contributors](https://github.com/ginge/FreeRTOS-Pebble/graphs/contributors) alike.  Daren't delay divulging details of the downright deluge of development deeds!  As always, if you'd like to add something, [send us a tweet](https://twitter.com/pebble_dev), or better still, [submit a pull request](https://github.com/pebble-dev/pebble-dev.github.io/pulls)! :bowtie:  

--- a/_posts/2018-02-15-rebble-web-services.md
+++ b/_posts/2018-02-15-rebble-web-services.md
@@ -3,6 +3,7 @@ layout: post
 title: "Pebbling after Fitbit: introducing the Rebble Web Services"
 date:   2018-02-15 18:00:00
 # categories: community
+author: "Katharine Berry"
 ---
 
 Hey there! [Katharine Berry](https://twitter.com/KatharineBerry) here. As you may well have heard

--- a/_posts/2018-06-13-get-ready-to-rebble.md
+++ b/_posts/2018-06-13-get-ready-to-rebble.md
@@ -3,6 +3,7 @@ layout: post
 title: "Getting Ready for Rebble"
 date:   2018-06-13 18:15:00
 # categories: community
+author: "Katharine Berry"
 ---
 
 Hi again! I'm [Katharine Berry](https://twitter.com/KatharineBerry), back

--- a/_posts/2018-07-01-rebble-era.md
+++ b/_posts/2018-07-01-rebble-era.md
@@ -3,6 +3,7 @@ layout: post
 title: "Ushering in the Rebble Era!"
 date:   2018-07-01 14:14:14
 # categories: community
+author: "Ish Ot Jr."
 ---
 
 It's a new day.  It's a new month (:ok_hand: :punch:).  But most importantly, it's a new era! :rocket:  It was over a year and half ago that [Rebble first put its stake in the ground](https://rebble.io/2016/12/09/rebble-pebble-reborn.html) as the unofficial spearhead organization for continuing the advancement of the Pebble platform in the absence of *Pebble Technology Corp.*  Re-reading that first blog post, a lot of the same feelings of fear, anxiety, resilience, and hope have been expressed in recent days as we make another transition - this time from *Pebble* web services to **Rebble Web Services**!  What does that mean?  Why is it necessary?  When is it happening?!  What do I need to do to participate??!  Read on, and all will be explained! :bowtie:  

--- a/_posts/2019-07-25-its-timeline-time.md
+++ b/_posts/2019-07-25-its-timeline-time.md
@@ -3,6 +3,7 @@ layout: post
 title: "It's Timeline time!"
 date:   2019-07-24 12:34:56
 # categories: community
+author: "Ish Ot Jr."
 ---
 
 Hi there!  Long time, no talk.  Sorry for the silence, but I assure you that

--- a/_posts/2019-07-29-the-shiny-rebble-future.md
+++ b/_posts/2019-07-29-the-shiny-rebble-future.md
@@ -3,6 +3,8 @@ layout: post
 title: "The shiny Rebble future: one year after the Pebble server shutdown"
 date:   2019-07-29 18:00:00
 # categories: community
+author: "Joshua Wise"
+alt-bio: "https://joshuawise.com"
 ---
 
 Hi out there, Rebble world!  [Joshua](https://joshuawise.com) on the

--- a/_posts/2019-09-30-appy-new-year.md
+++ b/_posts/2019-09-30-appy-new-year.md
@@ -3,6 +3,7 @@ layout: post
 title: "Appy New Year!"
 date:   2019-09-30 18:00:00
 # categories: community
+author: "Ish Ot Jr."
 ---
 
 Hi again!  It's a [new year](https://en.wikipedia.org/wiki/Rosh_Hashanah),

--- a/_posts/2019-11-02-rebble-rebble-everywhere.md
+++ b/_posts/2019-11-02-rebble-rebble-everywhere.md
@@ -3,6 +3,7 @@ layout: post
 title: "Rebble, Rebble Everywhere!"
 date:   2019-11-02 07:14:42
 # categories: community
+author: "Ish Ot Jr."
 ---
 
 *...and now a blog to link ([?!](https://www.poetryfoundation.org/poems/43997/the-rime-of-the-ancient-mariner-text-of-1834))*  

--- a/_posts/2020-04-13-squeezing-the-most-out-of-your-pebble.md
+++ b/_posts/2020-04-13-squeezing-the-most-out-of-your-pebble.md
@@ -2,6 +2,7 @@
 layout: post
 title: "Squeezing the most out of your Pebble"
 date:   2020-04-13 09:00:42
+author: "Will Murphy"
 # categories: community
 ---
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -8,7 +8,7 @@ baseUrl: /blog/
     {% for post in paginator.posts %}
         <article class="post">
             <div class="text-content">
-                <p class="metadata">{{ post.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
+	    	<p class="metadata">{{ post.date | date: "%b %-d, %Y" }}{% if post.author %} • by <a href="{% if post.alt-bio %}{{ post.alt-bio }}{% else %}/team#person-{{ post.author }}{% endif %}">{{ post.author }}</a>{% endif %}{% if post.meta %} • {{ post.meta }}{% endif %}</p>
                 <h2><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h2>
                 {{ post.content }}
               </div>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ permalink: /
     {% for post in site.posts limit:3 %}
         <article class="post">
             <div class="text-content">
-                <p class="metadata">{{ post.date | date: "%b %-d, %Y" }}{% if page.author %} • {{ page.author }}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}</p>
+	    	<p class="metadata">{{ post.date | date: "%b %-d, %Y" }}{% if post.author %} • by <a href="{% if post.alt-bio %}{{ post.alt-bio }}{% else %}/team#person-{{ post.author }}{% endif %}">{{ post.author }}</a>{% endif %}{% if post.meta %} • {{ post.meta }}{% endif %}</p>
                 <h2><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h2>
                 {{ post.excerpt }}
             </div>


### PR DESCRIPTION
This is a fix for issue #55. It allows your to add 
`author: $name` to a post, and it will add 'by $name' next to the date, as well as link to the team member on the teams page. 

If the author is not on the teams page, or wants the link to go elsewhere they can override the url with
`alt-bio: $url`
where $url is the link URL on the authors name.

Example Images:
![image](https://user-images.githubusercontent.com/24474651/79353141-913ce180-7f32-11ea-9036-ae353a6eb54b.png)
![image](https://user-images.githubusercontent.com/24474651/79353187-a0bc2a80-7f32-11ea-9f67-50ffa9b36069.png)

The author name should ideally exactly match the name in team.yml. If it doesn't, and no alt-bio is provided, then the link will just go to the teams page.

I've also gone back through the old posts and added attribution (including linking @jwise 's post to his domain name, as he's not on the team page?!)