### PR TITLE
Update url in _config to https:// to prevent insecure flag in browsers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ title: Rebble
 description: >
   The goal of Rebble is to maintain and advance Pebble functionality in the absence of Pebble Technology Corp.
 baseurl: ""		# no trailing slash
-url: "http://rebble.io"	# no trailing slash
+url: "https://rebble.io"	# no trailing slash
 excerpt_separator: <!--more-->
 
 about: >


### PR DESCRIPTION
Most browsers provide a visual warning to the user that some parts of the page are 'insecure' when loading rebble.io

![image](https://user-images.githubusercontent.com/24474651/82725798-71d66880-9cd7-11ea-8bb7-9c2a7f7c9f66.png)

This is happening on rebble.io because the site url in _config is http:// so image links get auto generated by Jekyll as http://...

![image](https://user-images.githubusercontent.com/24474651/82725820-a518f780-9cd7-11ea-97fd-b2db4499b9f6.png)

Even though Github returns a 301 redirect to https://, the 'some parts of this page are insecure' warning is still present. 

Changing to `url: https://` will potentially add an extra step to building the site locally, but this was probably already the case.