### PR TITLE
Switch footer images to use relative path

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -5,7 +5,7 @@
     </div>
     <div class="text-content">
       {% for item in site.data.socials %}
-        <a href="{{ item.url }}"><img class="footer-icon" alt="icon-{{ item.name }}" src="{{ site.url }}/images/social-icons/{{ item.icon }}"></img></a>
+        <a href="{{ item.url }}"><img class="footer-icon" alt="icon-{{ item.name }}" src="/images/social-icons/{{ item.icon }}"></img></a>
       {% endfor %}
     </div>
     {% include mailinglist.html %}


### PR DESCRIPTION
Currently rebble.io gets flagged as 'partially insecure' because the footer images use the FQDN pulled from _config.md's `url: ` which starts `http://`

![image](https://user-images.githubusercontent.com/24474651/82725798-71d66880-9cd7-11ea-8bb7-9c2a7f7c9f66.png)

By changing to a relative path the images will have a full https url, and no warning will occur.

This is a better solution to the issue than the previously raised #82 