### PR TITLE
Remove http://rebble.io url from _config so links are relative

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ title: Rebble
 description: >
   The goal of Rebble is to maintain and advance Pebble functionality in the absence of Pebble Technology Corp.
 baseurl: ""		# no trailing slash
-url: "http://rebble.io"	# no trailing slash
+url: ""	# no trailing slash
 excerpt_separator: <!--more-->
 
 about: >


### PR DESCRIPTION
Currently when you load https://rebble.io/team/, we get a mixed content https warning:
![image](https://user-images.githubusercontent.com/24474651/90483415-969e7880-e12c-11ea-81b5-0162475a9014.png)

This is caused by the images loading initially as http then getting redirected to https:
![image](https://user-images.githubusercontent.com/24474651/90483553-c9487100-e12c-11ea-99e5-3af4b90ddfff.png)

The fix is to remove the 'url: http://rebble.io' config item from _config, which will cause all links to be relative
