### PR TITLE
Add Joshua's blog to author bio override

### DIFF
--- a/_posts/2020-09-04-rebble-grants.md
+++ b/_posts/2020-09-04-rebble-grants.md
@@ -3,6 +3,7 @@ layout: post
 title: "Announcing: Rebble Grants!"
 date:   2020-09-04 10:00:42
 author: "Joshua Wise"
+alt-bio: "https://joshuawise.com"
 # categories: community
 ---
 


### PR DESCRIPTION
Because @jwise isn't in the teams page(!!) the auto-generated bio link on his name goes to the teams page, which he's not on. I've added the alt-bio attribute which will override this behavior. Now when someone clicks the author name on the Rebble grants post it goes to Joshua's personal site. 

Joshua get yourself on the teams page my man!