### PR TITLE
Add handy redirect link to play store at /charon. Similar to /discord

### DIFF
--- a/charon/index.html
+++ b/charon/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0;https://play.google.com/store/apps/details?id=io.rebble.charon" />
+<title>Join us on Discord!</title>
+</head>
+<body>
+If you aren't redirected, <a href="https://play.google.com/store/apps/details?id=io.rebble.charon">click here!</a>
+</body>
+</html>


### PR DESCRIPTION
This is just a meta refresh redirect to the google play store.

In the same vein that people can point to rebble.io/discord, now we can point to rebble.io/charon