### PR TITLE
Add the Android app to /apk

### DIFF
--- a/apk/index.html
+++ b/apk/index.html
@@ -10,6 +10,6 @@ date:   2015-06-12 11:56:42
 		The original Pebble app for Android is no longer available on the Google Play Store.
 		<br>
 		Rebble hosts the latest version of the APK, which you can download below:<br><br>
-		<a class="button orange" href="{{ site.baseurl }}pebbleApp.apk">Download Android App</a>
+		<a class="button orange" href="https://binaries.rebble.io/apks/pebble-4.4.2.apk">Download Android App</a>
         </div>
     </section>

--- a/apk/index.html
+++ b/apk/index.html
@@ -1,0 +1,15 @@
+---
+layout: default
+title: "Rebble"
+date:   2015-06-12 11:56:42
+---
+    <section>
+        <div class="text-content">
+		<h1> Android APK Download </h1>
+
+		The original Pebble app for Android is no longer available on the Google Play Store.
+		<br>
+		Rebble hosts the latest version of the APK, which you can download below:<br><br>
+		<a class="button orange" href="{{ site.baseurl }}pebbleApp.apk">Download Android App</a>
+        </div>
+    </section>


### PR DESCRIPTION
This PR adds the android app (com.getpebble.android.basalt) APK to a new directory, /apk

It's the APK taken from https://www.apkmirror.com/apk/pebble-technology-corp/pebble/pebble-4-4-2-1405-62d45d7d7-endframe-release/pebble-4-4-2-1405-62d45d7d7-endframe-android-apk-download/

I have also added an index page in /apk, so anyone visiting https://rebble.io/apk will see:

![image](https://user-images.githubusercontent.com/24474651/110001963-cdc12980-7d0c-11eb-8e35-8decb09d192b.png)

The button goes to rebble.io/apk/pebbleApp.apk, which downloads the APK