### PR TITLE
Make 'My Account' go straight to auth.rebble.io/account

### DIFF
--- a/_data/index.yml
+++ b/_data/index.yml
@@ -17,4 +17,4 @@
   permalink: "/projects/"
 
 - display: "my account 🔒"
-  link: "https://auth.rebble.io"
+  link: "https://auth.rebble.io/account"


### PR DESCRIPTION
This is an update to the previous PR. On reflection if the aim is to get people in front of the subscription control faster, there's no point sending them to auth.rebble.io just to have them find and click the 'manage your subscription' button