### PR TITLE
Add contact page, add footer link

### DIFF
--- a/_data/index.yml
+++ b/_data/index.yml
@@ -10,11 +10,11 @@
 - display: "faq"
   permalink: "/faq/"
 
-- display: "team"
-  permalink: "/team/"
-
 - display: "projects"
   permalink: "/projects/"
+
+- display: "contact"
+  permalink: "/contact/"
 
 - display: "my account 🔒"
   link: "https://auth.rebble.io/account"

--- a/_data/socials.yml
+++ b/_data/socials.yml
@@ -11,5 +11,5 @@
   icon: facebook.png
 
 - name: email
-  url: mailto:support@rebble.io
+  url: /contact/
   icon: email.png

--- a/_includes/contactus.html
+++ b/_includes/contactus.html
@@ -1,0 +1,1 @@
+<a href="/contact">Contact</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,5 +8,5 @@
         <a href="{{ item.url }}"><img class="footer-icon" alt="icon-{{ item.name }}" src="/images/social-icons/{{ item.icon }}"></img></a>
       {% endfor %}
     </div>
-    {% include mailinglist.html %}
+    {% if page.title != "Contact" %}{% include contactus.html %}{% endif %}
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,12 +1,12 @@
 <footer>
     <div class="text-content">
         <p>Join us on the <a href="https://discordapp.com/invite/aRUAYFN">
-            officially unofficial Pebble Discord server!</a></p>
+            officially unofficial Pebble Discord server!</a> - or <a href="/contact">contact Rebble</a>.</p>
     </div>
     <div class="text-content">
       {% for item in site.data.socials %}
         <a href="{{ item.url }}"><img class="footer-icon" alt="icon-{{ item.name }}" src="/images/social-icons/{{ item.icon }}"></img></a>
       {% endfor %}
     </div>
-    {% if page.title != "Contact" %}{% include contactus.html %}{% endif %}
+    {% include mailinglist.html %}
 </footer>

--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,27 @@
+---
+layout: text-page
+title: "Contact"
+date:   2021-07-30 00:00:00
+
+permalink: /contact/
+---
+
+## Contact Rebble
+
+### General Enquiries
+
+To get in touch with Rebble, you can email us at [support@rebble.io](mailto://support@rebble.io).
+
+### Technical Support
+
+If you require assistance with Rebble services, you may find it useful to check the [Help Center](https://help.rebble.io). If that does not resolve your problem, either send us an email at [support@rebble.io](mailto://support@rebble.io) or consider visiting the [Rebble Discord server](/discord).
+
+### Appstore Content
+
+If you have an issue with an app or watchface on the [Rebble appstore](https://apps.rebble.io), please contact us by email at [support@rebble.io](mailto://support@rebble.io) with the word 'appstore' in the email subject. Please include a link to the app or watchface in question.
+
+### Privacy & TOS
+
+If you are interested in our privacy policy or terms of service, they can be viewed using the following links:   
+	- [Privacy policy](/privacy)   
+	- [Terms of Service](/tos)

--- a/contact.md
+++ b/contact.md
@@ -20,6 +20,8 @@ If you require assistance with Rebble services, you may find it useful to check 
 
 If you have an issue with an app or watchface on the [Rebble appstore](https://apps.rebble.io), please contact us by email at [support@rebble.io](mailto://support@rebble.io) with the word 'appstore' in the email subject. Please include a link to the app or watchface in question.
 
+If you have a copyright issue with appstore content, please see the [relevant section of our terms of service for more information](/tos/#e-copyright-infringement-and-dmca-policy).
+
 ### Privacy & TOS
 
 If you are interested in our privacy policy or terms of service, they can be viewed using the following links:   

--- a/contact.md
+++ b/contact.md
@@ -8,22 +8,48 @@ permalink: /contact/
 
 ## Contact Rebble
 
-### General Enquiries
+### Technical support
 
-To get in touch with Rebble, you can email us at [support@rebble.io](mailto://support@rebble.io).
+If you need help with Rebble services, you may find it useful to check the
+[Help Center](https://help.rebble.io).  If that does not resolve your
+problem, consider visiting the [Rebble Discord server](/discord) -- we have
+a vibrant community ready to help out!
 
-### Technical Support
+### Billing questions
 
-If you require assistance with Rebble services, you may find it useful to check the [Help Center](https://help.rebble.io). If that does not resolve your problem, either send us an email at [support@rebble.io](mailto://support@rebble.io) or consider visiting the [Rebble Discord server](/discord).
+If you have questions about a bill from "REBBLE ALLIANCE" on your credit
+card, or have any other questions about the paid part of the Rebble
+services, you can e-mail us at
+[support@rebble.io](mailto:support@rebble.io).  Please keep in mind that
+Rebble is run mostly as a volunteer project, and isn't anybody's full time
+job ... we tend to read e-mail in batches, and so it might be a week or two
+before you get a response, but we will get back to you!
 
-### Appstore Content
+### Appstore content
 
-If you have an issue with an app or watchface on the [Rebble appstore](https://apps.rebble.io), please contact us by email at [support@rebble.io](mailto://support@rebble.io) with the word 'appstore' in the email subject. Please include a link to the app or watchface in question.
+If you have an issue with an app or watchface on the [Rebble
+appstore](https://apps.rebble.io), please contact us by email at
+[support@rebble.io](mailto://support@rebble.io) with the word 'appstore' in
+the email subject.  Please include a link to the app or watchface in
+question.
 
-If you have a copyright issue with appstore content, please see the [relevant section of our terms of service for more information](/tos/#e-copyright-infringement-and-dmca-policy).
+If you have a copyright issue with appstore content, please see the
+[relevant section of our terms of service for more
+information](/tos/#e-copyright-infringement-and-dmca-policy).
 
-### Privacy & TOS
+### Privacy and Terms of Service
 
-If you are interested in our privacy policy or terms of service, they can be viewed using the following links:   
+If you are interested in our privacy policy or our terms of service, they can be viewed using the following links:
 	- [Privacy policy](/privacy)   
 	- [Terms of Service](/tos)
+
+### Anything else
+
+The fastest way to get help with Rebble is to [join us on
+Discord](/discord), where there are plenty of folks (including Rebble
+administrators!) who'd love to help out.  But if you need to get in touch
+for any other reason, feel free to email us at
+[support@rebble.io](mailto:support@rebble.io).  Please note that it's very
+hard for us to provide technical support via e-mail -- we mostly use e-mail
+for business-related questions (billing, etc) -- so if at all possible, we
+really do encourage you to use Discord for that kind of thing!

--- a/privacy.md
+++ b/privacy.md
@@ -180,7 +180,7 @@ Our emails might contain a pixel tag, which is a small, clear image that can tel
 
 ### Resolving complaints
 
-If you have concerns about the way Rebble is handling your User Personal Information, please let us know immediately. We want to help. You may email us directly at privacy@rebble.io with the subject line "Privacy Concerns." 
+If you have concerns about the way Rebble is handling your User Personal Information, please let us know immediately. We want to help. You may email us directly at support@rebble.io with the subject line "Privacy Concerns." 
 
 ### Changes to our Privacy Statement
 Although most changes are likely to be minor, Rebble may change our Privacy Statement from time to time. We will provide notification to Users of material changes to this Privacy Statement through our Website at least 30 days prior to the change taking effect by posting a notice on our home page or sending email to the email address specified in your Rebble account. We will also update our [Site Policy](https://github.com/pebble-dev/site-policy) repository, which tracks all changes to this policy. For changes to this Privacy Statement that do not affect your rights, we encourage visitors to check our Site Policy repository frequently.
@@ -189,4 +189,4 @@ Although most changes are likely to be minor, Rebble may change our Privacy Stat
 This Privacy Statement is licensed under this [Creative Commons Zero license](https://creativecommons.org/publicdomain/zero/1.0/). For details, see our [site-policy repository](https://github.com/pebble-dev/site-policy).
 
 ### Contacting Rebble
-Questions regarding Rebble's Privacy Statement or information practices should be directed to privacy@rebble.io.
+Questions regarding Rebble's Privacy Statement or information practices should be directed to support@rebble.io.

--- a/privacy.md
+++ b/privacy.md
@@ -50,7 +50,7 @@ We collect this information to better understand how our website visitors use Re
 
 If you **create an account**, we require some basic information at the time of account creation. You may also have the option to give us more information if you want to, and this may include "User Personal Information."
 
-"User Personal Information" is any information about one of our users which could, alone or together with other information, personally identify him or her. Information such as a user name and password, an email address, a real name, and a photograph are examples of “User Personal Information.” User Personal Information includes Personal Data as defined in the General Data Protection Regulation.
+"User Personal Information" is any information about one of our users which could, alone or together with other information, personally identify them. Information such as a user name and password, an email address, a real name, and a photograph are examples of “User Personal Information.” User Personal Information includes Personal Data as defined in the General Data Protection Regulation.
 
 User Personal Information does not include aggregated, non-personally identifying information. We may use aggregated, non-personally identifying information to operate, improve, and optimize our website and service.
 

--- a/tos.md
+++ b/tos.md
@@ -150,7 +150,7 @@ You retain all moral rights to Your Content that you upload, publish, or submit 
 To the extent this agreement is not enforceable by applicable law, you grant Rebble the rights we need to use Your Content without attribution and to make reasonable adaptations of Your Content as necessary to render the Website and provide the Service.
 
 ### E. Copyright Infringement and DMCA Policy
-If you believe that content on our website violates your copyright, please contact us. If you are a copyright owner and you believe that content on Rebble violates your rights, please contact us by emailing copyright@rebble.io. There may be legal consequences for sending a false or frivolous takedown notice. Before sending a takedown request, you must consider legal uses such as fair use and licensed uses.
+If you believe that content on our website violates your copyright, please contact us. If you are a copyright owner and you believe that content on Rebble violates your rights, please contact us by emailing support@rebble.io. There may be legal consequences for sending a false or frivolous takedown notice. Before sending a takedown request, you must consider legal uses such as fair use and licensed uses.
 
 We will terminate the Accounts of repeat infringers of this policy.
 

--- a/tos.md
+++ b/tos.md
@@ -152,7 +152,7 @@ To the extent this agreement is not enforceable by applicable law, you grant Reb
 ### E. Copyright Infringement and DMCA Policy
 If you believe that content on our website violates your copyright, please contact us. If you are a copyright owner and you believe that content on Rebble violates your rights, please contact us by emailing support@rebble.io. There may be legal consequences for sending a false or frivolous takedown notice. Before sending a takedown request, you must consider legal uses such as fair use and licensed uses.
 
-We will terminate the Accounts of repeat infringers of this policy.
+We may terminate the Accounts of repeat infringers of this policy.
 
 ### F. Intellectual Property Notice
 **Short version:** *We own the service and all of our content. In order for you to use our content, we give you certain rights to it, but you may only use our content in the way we have allowed.*
@@ -213,7 +213,7 @@ Our pricing and payment terms are available at [rebble.io/pricing](https://rebbl
 
 #### 3. Billing Schedule; No Refunds
 - For monthly or yearly payment plans, the Service is billed in advance on a monthly or yearly basis respectively and is non-refundable. There will be no refunds or credits for partial months of service, downgrade refunds, or refunds for months unused with an open Account; however, the service will remain active for the length of the paid billing period.
-- In order to treat everyone equally, no exceptions will be made.
+- Exceptions to this policy may be granted at the sole discretion of Rebble.
 
 #### 4. Authorization
 By agreeing to these Terms, you are giving us permission to charge your on-file credit card or other approved methods of payment for fees that you authorize for Rebble.


### PR DESCRIPTION
This PR adds a new 'contact Rebble' page to /contact, and replaces the mailing list signup input in the footer with a 'contact' link:

![image](https://user-images.githubusercontent.com/24474651/127671714-b2e8f9d5-8d05-482e-b107-7ef22bde2323.png)

I don't think the mailing list is still used, hence my removing it.

The contact page currently looks like this:

![image](https://user-images.githubusercontent.com/24474651/127672413-0bba093b-aa32-41cb-9537-72acbcda0f97.png)

The wording is just a draft but covers the basics. Might be good to have a dedicated appstore@rebble.io email or something.