### PR TITLE
Add hackathon sticker

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,10 @@ github_username:     pebble-dev
 paginate: 5
 paginate_path: "/blog/:num/"
 
+# Controls the hackathon page sticker
+hackathonActive: true
+hackathonUrl: "/hackathon-001"
+
 # Build settings
 markdown: kramdown
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,5 +11,11 @@
             <span class="pagename">blog</span>
         {% endif %}
     </span>
+    {% if site.hackathonActive == true %}
+       <a href="{{ site.hackathonUrl }}"> <div class="homepage-sticker">
+            <img src="https://dev-portal.rebble.io/res/img/large_icon_space.svg"></img>
+            <span> Hackathon!! </span>
+        </div></a>
+    {% endif %}
     <i class="rebble-logo-spacer large-icon"></i>
 </header>

--- a/_scss/home.scss
+++ b/_scss/home.scss
@@ -39,3 +39,32 @@
 		margin-left: 0;
 	}
 }
+
+.homepage-sticker {
+	text-align: center;
+	justify-content: center;
+	vertical-align: middle;
+	background-color: $dev-portal-blue;
+	border: 2px dashed $rebble-color;
+	position: absolute;
+	top: 30px;
+	left: 60%;
+	border-radius: 50%;
+	display: inline-block;
+	width: 120px;
+	height: 120px;
+	// line-height: 100px;
+	transform: rotate(5deg);
+	font-family: montserrat, Arial, Sans-Serif;
+	color: white;
+}
+.homepage-sticker span {
+	position: relative;
+	top: -10px;
+	color: $dev-portal-blue;
+}
+@media (max-width : 500px) {
+	.homepage-sticker {
+		display: none;
+	}
+}


### PR DESCRIPTION
This adds a new sticker to the homepage advertising the hackathon. It's controlled by 2 new site variables is _config.yml:

hackathonActive: true
hackathonUrl: "/hackathon-001"

-----
hackathonActive controls whether the sticker shows, hackathonUrl controls the hyperlink location.

The sticker does not show on mobile because it gets in the way.